### PR TITLE
README.md+package.json: update URLS s/djsatok/alexauroradev/

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The steps below are for the mainnet, same steps might be reproduced for testnets
 1. Make sure you have installed npm
 2. Install NEAR CLI: `$ npm install -g near-cli`
 3. Install TypeScript: `$ npm install -g typescript`
-4. Clone this repo: `$ git clone git@github.com:djsatok/bridge-testing.git` OR `$ git clone https://github.com/djsatok/bridge-testing.git`
+4. Clone this repo: `$ git clone git@github.com:alexauroradev/bridge-testing.git` OR `$ git clone https://github.com/alexauroradev/bridge-testing.git`
 5. `$ cd bridge-testing` & `$ npm install`.
 6. Make sure you have an access to your Ethereum account (you have a private key) and you know the address of the ERC20 token that you would like to transfer.
 9. Make sure you have an access to your NEAR account through NEAR Wallet: https://wallet.near.org/

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/djsatok/bridge-testing.git"
+    "url": "git+https://github.com/alexauroradev/bridge-testing.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/djsatok/bridge-testing/issues"
+    "url": "https://github.com/alexauroradev/bridge-testing/issues"
   },
-  "homepage": "https://github.com/djsatok/bridge-testing#readme",
+  "homepage": "https://github.com/alexauroradev/bridge-testing#readme",
   "dependencies": {
     "bn": "^1.0.5",
     "eth-object": "near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7",


### PR DESCRIPTION
This repository still refers to `djsatok` instead of `alexauroradev` in two files.

This pull request should rectify that issue.